### PR TITLE
fix: restore default package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 readme = "README.md"
-package-mode = false
 
 [tool.poetry.dependencies]
 click = "~=8.1"


### PR DESCRIPTION
Hi, this restores default behavior which Poetry calls **package mode**. Otherwise Poetry only installs dependencies then complains the script isn't installed.

https://python-poetry.org/docs/basic-usage/#operating-modes

Closes #3 